### PR TITLE
[codex] fix tmp path traversal advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4344,8 +4344,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -9490,9 +9490,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

This updates the transitive `tmp` dependency from `0.2.5` to `0.2.7` in `pnpm-lock.yaml`.

GitHub Dependabot reported `CVE-2026-44705` / `GHSA-ph9p-34f9-6g65`, a high-severity path traversal vulnerability in `tmp` versions earlier than `0.2.6`. The vulnerable package entered this project through `@netlify/vite-plugin-tanstack-start`, `@netlify/vite-plugin`, Netlify development dependencies, and `tmp-promise`.

## User Impact

The vulnerable `tmp` release can allow temporary file creation outside the intended directory when untrusted values reach its `prefix`, `postfix`, or `dir` options. Updating the resolved transitive dependency removes that vulnerable implementation from the installed dependency tree.

## Root Cause

`tmp-promise@3.0.3` permits compatible `tmp` releases through its existing semver range, but the project lockfile resolved that range to vulnerable `tmp@0.2.5`.

## Fix

The lockfile now resolves `tmp-promise@3.0.3` to official patched `tmp@0.2.7`. No application code or unrelated dependency versions changed.

## Validation

- `pnpm audit --json` reports zero vulnerabilities.
- `pnpm run typecheck` passes.
- `pnpm run build` passes.
- Local browser smoke testing passed for `/`, `/shows`, `/schedule`, `/about`, and `/contact`.
- `pnpm run test` currently reports that the repository has no test files.
